### PR TITLE
refactor: Harden Redis client, rendering, and shared state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,19 @@ jobs:
       matrix:
         rust:
           - 1.91.0
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }} --component rustfmt
-          rustup default ${{ matrix.rust }}
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo +${{ matrix.rust }} fmt --all -- --check
 
   clippy:
     needs: [fmt]
@@ -36,17 +38,19 @@ jobs:
       matrix:
         rust:
           - 1.91.0
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }} --component clippy
-          rustup default ${{ matrix.rust }}
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings -W clippy::all -W clippy::pedantic
+        run: cargo +${{ matrix.rust }} clippy --all-targets --all-features -- -D warnings -W clippy::all -W clippy::pedantic
 
   build:
     needs: [fmt, clippy]
@@ -61,13 +65,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
 
       - name: Run cargo build
-        run: cargo build --all-features
+        run: cargo +${{ matrix.rust }} build --all-features
 
   test:
     needs: [build]
@@ -77,17 +81,18 @@ jobs:
       matrix:
         rust:
           - 1.91.0
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
       - name: Nextest
-        run: cargo nextest run --workspace --all-targets
+        run: cargo +${{ matrix.rust }} nextest run --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,33 @@ on:
     branches: "*"
 
 jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
+
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
+  machete:
+    name: Machete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+      - run: cargo machete
+
   fmt:
     name: Fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --component rustfmt
+          rustup default ${{ matrix.rust }}
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -41,14 +40,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-          components: clippy
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --component clippy
+          rustup default ${{ matrix.rust }}
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings  -W clippy::all -W clippy::pedantic
+        run: cargo clippy --all-targets --all-features -- -D warnings -W clippy::all -W clippy::pedantic
 
   build:
     needs: [fmt, clippy]
@@ -63,12 +61,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
 
-      - name: Run cargo check
+      - name: Run cargo build
         run: cargo build --all-features
 
   test:
@@ -83,10 +81,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
 
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
 
       - name: Install nextest
         uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.91.0
+          - 1.93.1
 
     steps:
       - name: Checkout sources
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.91.0
+          - 1.93.1
 
     steps:
       - name: Checkout sources
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.91.0
+          - 1.93.1
 
     steps:
       - name: Checkout sources
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.91.0
+          - 1.93.1
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
-name: CI 
+name: CI
 
 on:
-    push:
-      branches: '*'
-      tags:
-        - 'v*'
-    pull_request:
-      branches: '*'
+  push:
+    branches: "*"
+    tags:
+      - "v*"
+  pull_request:
+    branches: "*"
 
 jobs:
   fmt:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.78.0 
+          - 1.91.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.78.0
+          - 1.91.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
@@ -52,12 +52,12 @@ jobs:
 
   build:
     needs: [fmt, clippy]
-    name: Build 
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.78.0
+          - 1.91.0
 
     steps:
       - name: Checkout sources
@@ -73,12 +73,12 @@ jobs:
 
   test:
     needs: [build]
-    name: Tests 
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
-          - 1.78.0
+          - 1.91.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4.1.6
@@ -91,5 +91,5 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Nextest 
+      - name: Nextest
         run: cargo nextest run --workspace --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   audit:
     name: Audit
     runs-on: ubuntu-latest
+    # TODO: remove continue-on-error once known advisories are triaged
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4.1.6
       - uses: taiki-e/install-action@v2
@@ -22,6 +24,8 @@ jobs:
   deny:
     name: Deny
     runs-on: ubuntu-latest
+    # TODO: remove continue-on-error once deny.toml license allowlist is complete
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4.1.6
       - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+minimum_pre_commit_version: "3.5.0"
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-toml
+      - id: check-json
+
+  - repo: https://github.com/AndrejOrsula/pre-commit-cargo
+    rev: 0.5.0
+    hooks:
+      - id: cargo-fmt
+      - id: cargo-clippy
+        args: ["--", "-D", "warnings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ human-panic = "2.0.8"
 json5 = "1.3.1"
 lazy_static = "1.5.0"
 libc = "0.2.186"
+parking_lot = "0.12"
 log = "0.4.29"
 pretty_assertions = "1.4.1"
 ratatui = { version = "0.28.1", features = ["serde", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ ratatui = { version = "0.28.1", features = ["serde", "macros"] }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.150"
 serde_with = "3.20.0"
-signal-hook = "0.4.4"
 strip-ansi-escapes = "0.2.1"
 strum = { version = "0.28.0", features = ["derive"] }
 itertools = "0.13.0"
@@ -47,7 +46,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "serde"] }
 
 redis = { version = "1.2.1", default-features = false, features = ["aio", "tokio-comp", "connection-manager"]}
 byte-unit = { version = "5.2.0", features = ["serde", "byte"], default-features = false}
-tui-input = "0.10.1"
 tui-textarea = "0.6.1"
 rpassword = "7.5.2"
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,91 @@
 # redis-rover
 
 A Redis terminal-ui client written in rust 🦀
+
+`redis-rover` (`rrover`) is a keyboard-driven TUI client for Redis. It lets you browse keyspaces, inspect key metadata, filter by pattern, and monitor server info — all from the terminal. Built with [ratatui](https://github.com/ratatui-org/ratatui) and powered by async I/O via Tokio.
+
+**Features:**
+
+- Browse and filter Redis keys with type-colored badges
+- Paginate through large keyspaces via SCAN
+- Live Redis server info in the footer
+- Fully configurable key bindings, colors, and styles via a config file (JSON5, YAML, TOML, INI)
+
+---
+
+## Installation
+
+**From crates.io:**
+
+```bash
+cargo install redis-rover
+```
+
+**Prebuilt binaries** for macOS (x86\_64, arm64), Linux (x86\_64, aarch64), and Windows are available on the [GitHub releases page](https://github.com/danik-tro/redis-rover/releases).
+
+---
+
+## Usage
+
+```bash
+rrover
+```
+
+Connects to Redis at `localhost:6379` by default.
+
+---
+
+## Development
+
+**Prerequisites:**
+
+- Rust 1.91 (the toolchain is pinned via `rust-toolchain.toml` — `rustup` will pick it up automatically)
+- A running Redis instance on `localhost:6379`
+
+**Common commands:**
+
+```bash
+# Build
+cargo build
+
+# Run
+cargo run
+
+# Run tests
+cargo test
+
+# Lint
+cargo clippy
+
+# Check formatting
+cargo fmt --check
+```
+
+**Pre-commit hooks:**
+
+This repo uses [prek](https://github.com/j178/prek) (a Rust-based drop-in for the `pre-commit` framework) to run `cargo fmt` and `cargo clippy` before every commit.
+
+```bash
+# Install prek (macOS)
+brew install prek
+
+# Or via cargo
+cargo install prek
+
+# Install the git hooks
+prek install
+
+# Run all hooks manually
+prek run --all-files
+```
+
+---
+
+## Contributing
+
+1. Fork the repository and create a branch from `master`
+2. Install the pre-commit hooks (`prek install`) — they enforce formatting and lints locally
+3. Make your changes and ensure `prek run --all-files` passes
+4. Open a pull request — CI will run `cargo fmt`, `cargo clippy`, `cargo build`, and `cargo nextest` automatically
+
+Please keep commits focused and PRs scoped to a single concern.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+[advisories]
+version = 2
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "Unicode-DFL",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,6 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "ISC",
-    "Unicode-DFL",
-    "Zlib",
 ]
 
 [bans]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91"
+channel = "1.93"

--- a/src/action.rs
+++ b/src/action.rs
@@ -17,6 +17,8 @@ pub enum Action {
     LoadKeySpace,
     RefreshSpace,
     LoadKeysIntoKeySpace,
+    RequestSelectedValue,
+    LoadSelectedValueIntoView,
     LoadNextPage,
     LoadPreviousPage,
     SetKeyspaceFilter,

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crossterm::event::KeyCode;
 use ratatui::{
     buffer::Buffer,
     crossterm::event::KeyEvent,
-    layout::{Flex, Layout},
+    layout::{Constraint, Flex, Layout},
     prelude::Rect,
     style::Stylize,
     widgets::{Block, StatefulWidget, Widget},
@@ -55,7 +55,7 @@ impl App {
         redis_tx: broadcast::Sender<RedisEvent>,
         tick_rate: f64,
         frame_rate: f64,
-    ) -> Result<Self> {
+    ) -> Self {
         let _ = config::get();
 
         let mode = Mode::KeySpace;
@@ -63,7 +63,7 @@ impl App {
         let summary = Info::new(state.info.clone());
         let keyspace = KeySpace::new(Vec::new());
 
-        Ok(Self {
+        Self {
             state,
             summary,
             keyspace,
@@ -76,9 +76,15 @@ impl App {
             tx,
             rx,
             redis_tx,
-        })
+        }
     }
 
+    /// Run the main event loop until quit.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TUI fails to enter or if any action
+    /// dispatch returns an error.
     pub async fn run(&mut self, cancellation_token: CancellationToken) -> Result<()> {
         let mut tui = tui::Tui::new()?
             .tick_rate(self.tick_rate)
@@ -94,15 +100,18 @@ impl App {
             // TODO: refactor with async_channel crate
             // replace with select multiplex
             if let Some(e) = tui.next().await {
-                self.handle_event(e)?.map(|action| self.tx.send(action));
+                if let Some(action) = self.handle_event(&e) {
+                    let _ = self.tx.send(action);
+                }
             }
 
             while let Ok(action) = self.rx.try_recv() {
-                self.handle_action(action, &mut tui)?
-                    .map(|action| self.tx.send(action));
+                if let Some(next) = self.handle_action(&action, &mut tui)? {
+                    let _ = self.tx.send(next);
+                }
             }
             if self.should_quit {
-                tui.stop()?;
+                tui.stop();
                 break;
             }
         }
@@ -117,27 +126,24 @@ impl App {
         Ok(())
     }
 
-    fn handle_event(&mut self, e: tui::Event) -> Result<Option<Action>> {
-        let maybe_action = match e {
+    fn handle_event(&mut self, e: &tui::Event) -> Option<Action> {
+        match e {
             tui::Event::Quit => Some(Action::Quit),
             tui::Event::Tick => Some(Action::Tick),
             tui::Event::Render => Some(Action::Render),
-            tui::Event::Resize(x, y) => Some(Action::Resize(x, y)),
-            tui::Event::Key(key) => self.handle_key_event(key)?,
+            tui::Event::Resize(x, y) => Some(Action::Resize(*x, *y)),
+            tui::Event::Key(key) => self.handle_key_event(*key),
             _ => None,
-        };
-
-        Ok(maybe_action)
+        }
     }
 
-    fn handle_key_event(&mut self, key: KeyEvent) -> Result<Option<Action>> {
+    fn handle_key_event(&mut self, key: KeyEvent) -> Option<Action> {
         if self.keyspace.is_popup() && (key.code != KeyCode::Enter && key.code != KeyCode::Esc) {
             self.keyspace.handle_key(key);
-            return Ok(None);
+            return None;
         }
 
-        let action = self.handle_keybindings(key);
-        Ok(action.map(Into::into))
+        self.handle_keybindings(key)
     }
 
     fn handle_keybindings(&mut self, key: KeyEvent) -> Option<Action> {
@@ -154,11 +160,11 @@ impl App {
             .map(Into::into)
     }
 
-    fn handle_action(&mut self, action: Action, tui: &mut tui::Tui) -> Result<Option<Action>> {
-        if action != Action::Tick && action != Action::Render {
+    fn handle_action(&mut self, action: &Action, tui: &mut tui::Tui) -> Result<Option<Action>> {
+        if action != &Action::Tick && action != &Action::Render {
             log::debug!("{action:?}");
         }
-        match action {
+        match *action {
             Action::Tick => {
                 self.last_tick_key_events.drain(..);
             }
@@ -182,9 +188,7 @@ impl App {
             _ => {}
         }
 
-        let maybe_action = None;
-
-        Ok(maybe_action)
+        Ok(None)
     }
 
     fn draw(&mut self, tui: &mut tui::Tui) -> Result<()> {
@@ -202,8 +206,6 @@ impl StatefulWidget for AppWidget {
         let cfg = config::get();
         Block::default().bg(cfg.colors.base00).render(area, buf);
 
-        use ratatui::layout::Constraint;
-
         let [main, footer] = Layout::vertical([Constraint::Percentage(100), Constraint::Length(4)])
             .flex(Flex::Center)
             .margin(1)
@@ -217,9 +219,8 @@ impl StatefulWidget for AppWidget {
 /// Render logic
 impl App {
     fn render_main_block(&mut self, area: Rect, buf: &mut Buffer) {
-        match self.mode {
-            Mode::KeySpace => self.render_key_space(area, buf),
-            _ => {}
+        if self.mode == Mode::KeySpace {
+            self.render_key_space(area, buf);
         }
     }
 
@@ -325,24 +326,18 @@ impl App {
     }
 
     fn scroll_down(&mut self) {
-        match self.mode {
-            Mode::KeySpace => {
-                self.keyspace.scroll_next();
-                self.keyspace.clear_selected_value();
-                let _ = self.tx.send(Action::RequestSelectedValue);
-            }
-            _ => {}
+        if self.mode == Mode::KeySpace {
+            self.keyspace.scroll_next();
+            self.keyspace.clear_selected_value();
+            let _ = self.tx.send(Action::RequestSelectedValue);
         }
     }
 
     fn scroll_up(&mut self) {
-        match self.mode {
-            Mode::KeySpace => {
-                self.keyspace.scroll_previous();
-                self.keyspace.clear_selected_value();
-                let _ = self.tx.send(Action::RequestSelectedValue);
-            }
-            _ => {}
+        if self.mode == Mode::KeySpace {
+            self.keyspace.scroll_previous();
+            self.keyspace.clear_selected_value();
+            let _ = self.tx.send(Action::RequestSelectedValue);
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,6 +88,8 @@ impl App {
         // tui.mouse(true);
         tui.enter()?;
 
+        self.tx.send(Action::LoadKeySpace)?;
+
         loop {
             // TODO: refactor with async_channel crate
             // replace with select multiplex
@@ -167,6 +169,8 @@ impl App {
             Action::LoadKeySpace => self.load_keyspace(),
             Action::RefreshSpace => self.refresh_space(),
             Action::LoadKeysIntoKeySpace => self.load_new_keys(),
+            Action::RequestSelectedValue => self.request_selected_value(),
+            Action::LoadSelectedValueIntoView => self.load_selected_value(),
             Action::ScrollDown => self.scroll_down(),
             Action::ScrollUp => self.scroll_up(),
             Action::LoadNextPage => self.load_next_page(),
@@ -195,8 +199,9 @@ impl StatefulWidget for AppWidget {
     type State = App;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let cfg = config::get();
         Block::default()
-            .bg(config::get().colors.base00)
+            .bg(cfg.colors.base00)
             .render(area, buf);
 
         use ratatui::layout::Constraint;
@@ -252,7 +257,7 @@ impl App {
 
         {
             let pattern = self.keyspace.confirm_filter_pattern();
-            let mut state = self.state.keyspace_state.lock().unwrap();
+            let mut state = self.state.keyspace_state.lock();
             state.set_pattern(pattern.clone());
 
             self.keyspace.update_filters(pattern, None);
@@ -262,7 +267,7 @@ impl App {
 
     fn delete_keyspace_filter(&mut self) {
         {
-            let mut state = self.state.keyspace_state.lock().unwrap();
+            let mut state = self.state.keyspace_state.lock();
             state.delete_pattern();
             self.keyspace.update_filters(None, None);
         }
@@ -271,7 +276,7 @@ impl App {
 
     fn load_next_page(&mut self) {
         {
-            let mut state = self.state.keyspace_state.lock().unwrap();
+            let mut state = self.state.keyspace_state.lock();
             state.update_cursor();
             self.keyspace
                 .update_filters(state.pattern.clone(), state.cursor);
@@ -281,7 +286,7 @@ impl App {
 
     fn load_previous_page(&mut self) {
         {
-            let mut state = self.state.keyspace_state.lock().unwrap();
+            let mut state = self.state.keyspace_state.lock();
             state.set_previous_cursor();
             self.keyspace
                 .update_filters(state.pattern.clone(), state.cursor);
@@ -291,7 +296,25 @@ impl App {
 
     fn load_new_keys(&mut self) {
         self.keyspace
-            .set_keys(self.state.keys.lock().unwrap().clone());
+            .set_keys(self.state.keys.lock().clone());
+        self.keyspace.clear_selected_value();
+    }
+
+    fn request_selected_value(&self) {
+        let Some((key, r_type)) = self.keyspace.selected_key() else {
+            return;
+        };
+        if let Err(err) = self
+            .redis_tx
+            .send(RedisEvent::FetchValue { key, r_type })
+        {
+            log::error!("Failed to send FetchValue: {err:?}");
+        }
+    }
+
+    fn load_selected_value(&mut self) {
+        let value = self.state.selected_value.lock().clone();
+        self.keyspace.set_selected_value(value);
     }
 
     fn load_keyspace(&self) {
@@ -309,14 +332,22 @@ impl App {
 
     fn scroll_down(&mut self) {
         match self.mode {
-            Mode::KeySpace => self.keyspace.scroll_next(),
+            Mode::KeySpace => {
+                self.keyspace.scroll_next();
+                self.keyspace.clear_selected_value();
+                let _ = self.tx.send(Action::RequestSelectedValue);
+            }
             _ => {}
         }
     }
 
     fn scroll_up(&mut self) {
         match self.mode {
-            Mode::KeySpace => self.keyspace.scroll_previous(),
+            Mode::KeySpace => {
+                self.keyspace.scroll_previous();
+                self.keyspace.clear_selected_value();
+                let _ = self.tx.send(Action::RequestSelectedValue);
+            }
             _ => {}
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,9 +200,7 @@ impl StatefulWidget for AppWidget {
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let cfg = config::get();
-        Block::default()
-            .bg(cfg.colors.base00)
-            .render(area, buf);
+        Block::default().bg(cfg.colors.base00).render(area, buf);
 
         use ratatui::layout::Constraint;
 
@@ -295,8 +293,7 @@ impl App {
     }
 
     fn load_new_keys(&mut self) {
-        self.keyspace
-            .set_keys(self.state.keys.lock().clone());
+        self.keyspace.set_keys(self.state.keys.lock().clone());
         self.keyspace.clear_selected_value();
     }
 
@@ -304,10 +301,7 @@ impl App {
         let Some((key, r_type)) = self.keyspace.selected_key() else {
             return;
         };
-        if let Err(err) = self
-            .redis_tx
-            .send(RedisEvent::FetchValue { key, r_type })
-        {
+        if let Err(err) = self.redis_tx.send(RedisEvent::FetchValue { key, r_type }) {
             log::error!("Failed to send FetchValue: {err:?}");
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,18 +313,12 @@ fn parse_color(s: &str) -> Option<Color> {
                 .unwrap_or_default();
         Some(Color::Indexed(c))
     } else if s.contains("rgb") {
-        let red = u8::try_from(
-            (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default(),
-        )
-        .unwrap_or_default();
-        let green = u8::try_from(
-            (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default(),
-        )
-        .unwrap_or_default();
-        let blue = u8::try_from(
-            (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default(),
-        )
-        .unwrap_or_default();
+        let red = u8::try_from((s.as_bytes()[3] as char).to_digit(10).unwrap_or_default())
+            .unwrap_or_default();
+        let green = u8::try_from((s.as_bytes()[4] as char).to_digit(10).unwrap_or_default())
+            .unwrap_or_default();
+        let blue = u8::try_from((s.as_bytes()[5] as char).to_digit(10).unwrap_or_default())
+            .unwrap_or_default();
         let c = 16 + red * 36 + green * 6 + blue;
         Some(Color::Indexed(c))
     } else if s == "bold black" {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct AppConfig {
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct Config {
     #[serde(default, flatten)]
+    #[allow(dead_code, clippy::struct_field_names)]
     pub config: AppConfig,
     #[serde(default)]
     pub keybindings: KeyBindings,
@@ -38,6 +39,12 @@ pub struct Config {
 }
 
 impl Config {
+    /// Load the application configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the user's configuration file cannot be
+    /// read or deserialized into [`Config`].
     pub fn new() -> Result<Self, config::ConfigError> {
         let default_config: Config = json5::from_str(CONFIG_PATH).unwrap();
         let data_dir = crate::utils::get_data_dir();
@@ -61,7 +68,7 @@ impl Config {
                     .required(false),
             );
             if config_dir.join(file).exists() {
-                found_config = true
+                found_config = true;
             }
         }
         if !found_config {
@@ -70,20 +77,16 @@ impl Config {
 
         let mut cfg: Self = builder.build()?.try_deserialize()?;
 
-        for (mode, default_bindings) in default_config.keybindings.iter() {
+        for (mode, default_bindings) in &default_config.keybindings.0 {
             let user_bindings = cfg.keybindings.entry(*mode).or_default();
-            for (key, cmd) in default_bindings.iter() {
-                user_bindings
-                    .entry(key.clone())
-                    .or_insert_with(|| cmd.clone());
+            for (key, cmd) in default_bindings {
+                user_bindings.entry(key.clone()).or_insert(*cmd);
             }
         }
-        for (mode, default_styles) in default_config.styles.iter() {
+        for (mode, default_styles) in &default_config.styles.0 {
             let user_styles = cfg.styles.entry(*mode).or_default();
-            for (style_key, style) in default_styles.iter() {
-                user_styles
-                    .entry(style_key.clone())
-                    .or_insert_with(|| style.clone());
+            for (style_key, style) in default_styles {
+                user_styles.entry(style_key.clone()).or_insert(*style);
             }
         }
 
@@ -310,9 +313,18 @@ fn parse_color(s: &str) -> Option<Color> {
                 .unwrap_or_default();
         Some(Color::Indexed(c))
     } else if s.contains("rgb") {
-        let red = (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default() as u8;
-        let green = (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default() as u8;
-        let blue = (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default() as u8;
+        let red = u8::try_from(
+            (s.as_bytes()[3] as char).to_digit(10).unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        let green = u8::try_from(
+            (s.as_bytes()[4] as char).to_digit(10).unwrap_or_default(),
+        )
+        .unwrap_or_default();
+        let blue = u8::try_from(
+            (s.as_bytes()[5] as char).to_digit(10).unwrap_or_default(),
+        )
+        .unwrap_or_default();
         let c = 16 + red * 36 + green * 6 + blue;
         Some(Color::Indexed(c))
     } else if s == "bold black" {
@@ -397,7 +409,7 @@ mod tests {
     #[test]
     fn test_parse_color_rgb() {
         let color = parse_color("rgb123");
-        let expected = 16 + 1 * 36 + 2 * 6 + 3;
+        let expected = 16 + 36 + 2 * 6 + 3;
         assert_eq!(color, Some(Color::Indexed(expected)));
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -21,6 +21,7 @@ impl KeyBindings {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get_keybindings_for_command(&self, mode: Mode, command: Command) -> Vec<Vec<KeyEvent>> {
         let bindings_for_mode = self.0.get(&mode).cloned().unwrap_or_default();
         bindings_for_mode
@@ -30,6 +31,7 @@ impl KeyBindings {
             .collect_vec()
     }
 
+    #[allow(dead_code)]
     pub fn get_config_for_command(&self, mode: Mode, command: Command) -> Vec<String> {
         self.get_keybindings_for_command(mode, command)
             .iter()
@@ -66,15 +68,21 @@ impl<'de> Deserialize<'de> for KeyBindings {
     }
 }
 
+/// Parse a `<...>`-encoded key sequence into a list of [`KeyEvent`]s.
+///
+/// # Errors
+///
+/// Returns an error if the angle brackets are unbalanced or if any
+/// sub-sequence cannot be parsed by [`parse_key_event`].
 pub fn parse_key_sequence(raw: &str) -> Result<Vec<KeyEvent>, String> {
     if raw.chars().filter(|c| *c == '>').count() != raw.chars().filter(|c| *c == '<').count() {
-        return Err(format!("Unable to parse `{}`", raw));
+        return Err(format!("Unable to parse `{raw}`"));
     }
-    let raw = if !raw.contains("><") {
-        let raw = raw.strip_prefix('<').unwrap_or(raw);
-        let raw = raw.strip_prefix('>').unwrap_or(raw);
+    let raw = if raw.contains("><") {
         raw
     } else {
+        let raw = raw.strip_prefix('<').unwrap_or(raw);
+        let raw = raw.strip_prefix('>').unwrap_or(raw);
         raw
     };
     let sequences = raw
@@ -117,7 +125,7 @@ fn extract_modifiers(raw: &str) -> (&str, KeyModifiers) {
                 current = &rest[6..];
             }
             _ => break, // break out of the loop if no known prefix is detected
-        };
+        }
     }
 
     (current, modifiers)
@@ -158,8 +166,7 @@ fn parse_key_code_with_modifiers(
         "f11" => KeyCode::F(11),
         "f12" => KeyCode::F(12),
         "space" => KeyCode::Char(' '),
-        "hyphen" => KeyCode::Char('-'),
-        "minus" => KeyCode::Char('-'),
+        "hyphen" | "minus" => KeyCode::Char('-'),
         "tab" => KeyCode::Tab,
         c if c.len() == 1 => {
             let mut c = raw.chars().next().unwrap();
@@ -173,6 +180,7 @@ fn parse_key_code_with_modifiers(
     Ok(KeyEvent::new(c, modifiers))
 }
 
+#[allow(dead_code)]
 pub fn key_event_to_string(key_event: &KeyEvent) -> String {
     let char;
     let key_code = match key_event.code {
@@ -200,16 +208,16 @@ pub fn key_event_to_string(key_event: &KeyEvent) -> String {
             &char
         }
         KeyCode::Esc => "Esc",
-        KeyCode::Null => "",
-        KeyCode::CapsLock => "",
-        KeyCode::Menu => "",
-        KeyCode::ScrollLock => "",
-        KeyCode::Media(_) => "",
-        KeyCode::NumLock => "",
-        KeyCode::PrintScreen => "",
-        KeyCode::Pause => "",
-        KeyCode::KeypadBegin => "",
-        KeyCode::Modifier(_) => "",
+        KeyCode::Null
+        | KeyCode::CapsLock
+        | KeyCode::Menu
+        | KeyCode::ScrollLock
+        | KeyCode::Media(_)
+        | KeyCode::NumLock
+        | KeyCode::PrintScreen
+        | KeyCode::Pause
+        | KeyCode::KeypadBegin
+        | KeyCode::Modifier(_) => "",
     };
 
     let mut modifiers = Vec::with_capacity(3);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn tokio_main(args: Cli) -> Result<()> {
     let mut watcher = Runner::new(manager.clone(), state.clone(), tx.clone())
         .cancelation_token(cancellation_token.clone());
 
-    let mut app = App::new(state, tx, rx, watcher.tx(), args.tick_rate, args.frame_rate)?;
+    let mut app = App::new(state, tx, rx, watcher.tx(), args.tick_rate, args.frame_rate);
 
     watcher.start();
     app.run(cancellation_token).await?;

--- a/src/redis_client/client.rs
+++ b/src/redis_client/client.rs
@@ -4,22 +4,27 @@ use color_eyre::eyre::Result;
 
 use redis::{aio::ConnectionManager, AsyncCommands};
 
-use super::types::{KeyMeta, KeyValue, RedisInfo, RedisType};
+use super::types::{KeyValue, RedisInfo, RedisType};
 
 const VALUE_PREVIEW_LIMIT: isize = 100;
 
+/// Run `INFO` against Redis and parse the response into [`RedisInfo`].
+///
+/// # Errors
+///
+/// Returns an error if the command fails or the response cannot be parsed.
 // TODO: should be a better solution to handle this.
 pub async fn redis_info(manager: &mut ConnectionManager) -> Result<RedisInfo> {
     let info: String = redis::cmd("INFO").query_async(manager).await?;
 
     let mut map = std::collections::HashMap::new();
 
-    for c in info.split_terminator("\n") {
-        if c.starts_with("#") || c == "" {
+    for c in info.split_terminator('\n') {
+        if c.starts_with('#') || c.is_empty() {
             continue;
         }
 
-        let pair_op = c.split_once(":");
+        let pair_op = c.split_once(':');
 
         let Some((header, value)) = pair_op else {
             continue;
@@ -31,21 +36,12 @@ pub async fn redis_info(manager: &mut ConnectionManager) -> Result<RedisInfo> {
     Ok(serde_json::from_value(serde_json::json!(map))?)
 }
 
-pub async fn keys(
-    manager: &mut ConnectionManager,
-    cursor: Option<usize>,
-    pattern: Option<String>,
-) -> Result<(usize, Vec<String>)> {
-    let (cursor, keys): (usize, Vec<String>) = redis::cmd("SCAN")
-        .arg(cursor.unwrap_or_default())
-        .arg("MATCH")
-        .arg(pattern.unwrap_or_else(|| "*".into()))
-        .query_async(manager)
-        .await?;
-
-    Ok((cursor, keys))
-}
-
+/// Fetch the value behind a key, bounded to the first
+/// [`VALUE_PREVIEW_LIMIT`] items for collection types.
+///
+/// # Errors
+///
+/// Returns an error if any of the underlying Redis commands fails.
 pub async fn fetch_value(
     mut manager: ConnectionManager,
     key: &str,
@@ -80,29 +76,4 @@ pub async fn fetch_value(
         }
         RedisType::Json | RedisType::Unknown => Ok(KeyValue::Unknown),
     }
-}
-
-pub async fn fetch_meta_light(
-    manager: ConnectionManager,
-    key: &str,
-) -> Result<KeyMeta, Box<dyn std::error::Error + Sync + Send>> {
-    let mut conn = manager;
-    let (r_type, size, ttl): (String, Option<u128>, isize) = redis::pipe()
-        .cmd("TYPE")
-        .arg(key)
-        .cmd("MEMORY")
-        .arg("USAGE")
-        .arg(key)
-        .cmd("TTL")
-        .arg(key)
-        .query_async(&mut conn)
-        .await?;
-
-    Ok(KeyMeta {
-        key: key.into(),
-        r_type: RedisType::from(r_type),
-        size: size.unwrap_or_default(),
-        ttl,
-        value: KeyValue::Unknown,
-    })
 }

--- a/src/redis_client/client.rs
+++ b/src/redis_client/client.rs
@@ -1,10 +1,12 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use color_eyre::eyre::Result;
 
 use redis::{aio::ConnectionManager, AsyncCommands};
 
 use super::types::{KeyMeta, KeyValue, RedisInfo, RedisType};
+
+const VALUE_PREVIEW_LIMIT: isize = 100;
 
 // TODO: should be a better solution to handle this.
 pub async fn redis_info(manager: &mut ConnectionManager) -> Result<RedisInfo> {
@@ -44,78 +46,63 @@ pub async fn keys(
     Ok((cursor, keys))
 }
 
-pub async fn retrieve_type_and_value(
-    mut manager: redis::aio::ConnectionManager,
+pub async fn fetch_value(
+    mut manager: ConnectionManager,
     key: &str,
-) -> Result<(RedisType, KeyValue), Box<dyn std::error::Error + Send + Sync>> {
-    let r_type: String = manager.key_type(key).await?;
-    let r_type = RedisType::from(r_type);
-
+    r_type: RedisType,
+) -> Result<KeyValue, Box<dyn std::error::Error + Send + Sync>> {
     match r_type {
         RedisType::String => {
             let value: String = manager.get(key).await?;
-            Ok((r_type, KeyValue::String(value)))
+            Ok(KeyValue::String(value))
         }
         RedisType::List => {
-            let value: Vec<String> = manager.lrange(key, 0, -1).await?;
-            Ok((r_type, KeyValue::List(value)))
+            let value: Vec<String> = manager.lrange(key, 0, VALUE_PREVIEW_LIMIT - 1).await?;
+            Ok(KeyValue::List(value))
         }
         RedisType::Set => {
-            let value: HashSet<String> = manager.smembers(key).await?;
-            Ok((r_type, KeyValue::Set(value)))
+            let members: Vec<String> = redis::cmd("SRANDMEMBER")
+                .arg(key)
+                .arg(VALUE_PREVIEW_LIMIT)
+                .query_async(&mut manager)
+                .await?;
+            Ok(KeyValue::Set(members.into_iter().collect()))
         }
         RedisType::Hash => {
             let value: HashMap<String, String> = manager.hgetall(key).await?;
-            Ok((r_type, KeyValue::Hash(value)))
+            Ok(KeyValue::Hash(value))
         }
         RedisType::Zset => {
-            let value: Vec<(String, f64)> = manager.zrange_withscores(key, 0, -1).await?;
-            Ok((r_type, KeyValue::Zset(value)))
+            let value: Vec<(String, f64)> = manager
+                .zrange_withscores(key, 0, VALUE_PREVIEW_LIMIT - 1)
+                .await?;
+            Ok(KeyValue::Zset(value))
         }
-        RedisType::Json => {
-            // TODO: impleent json type
-            // let value: serde_json::Value = manager.get(key).await?;
-            Ok((r_type, KeyValue::Unknown))
-        }
-        RedisType::Unknown => Ok((r_type, KeyValue::Unknown)),
+        RedisType::Json | RedisType::Unknown => Ok(KeyValue::Unknown),
     }
 }
 
-pub async fn retrieve_memory_usage(
-    mut manager: redis::aio::ConnectionManager,
-    key: &str,
-) -> Result<u128, Box<dyn std::error::Error + Send + Sync>> {
-    let size: Option<u128> = redis::cmd("MEMORY")
-        .arg("USAGE")
-        .arg(key)
-        .query_async(&mut manager)
-        .await?;
-
-    Ok(size.unwrap_or_default())
-}
-
-pub async fn retrieve_ttl(
-    mut manager: redis::aio::ConnectionManager,
-    key: &str,
-) -> Result<isize, Box<dyn std::error::Error + Send + Sync>> {
-    Ok(manager.ttl(key).await?)
-}
-
-pub async fn fetch_meta(
-    manager: redis::aio::ConnectionManager,
+pub async fn fetch_meta_light(
+    manager: ConnectionManager,
     key: &str,
 ) -> Result<KeyMeta, Box<dyn std::error::Error + Sync + Send>> {
-    let ((r_type, value), size, ttl) = tokio::try_join!(
-        retrieve_type_and_value(manager.clone(), key),
-        retrieve_memory_usage(manager.clone(), key),
-        retrieve_ttl(manager, key),
-    )?;
+    let mut conn = manager;
+    let (r_type, size, ttl): (String, Option<u128>, isize) = redis::pipe()
+        .cmd("TYPE")
+        .arg(key)
+        .cmd("MEMORY")
+        .arg("USAGE")
+        .arg(key)
+        .cmd("TTL")
+        .arg(key)
+        .query_async(&mut conn)
+        .await?;
 
     Ok(KeyMeta {
-        value,
-        r_type,
-        size,
-        ttl,
         key: key.into(),
+        r_type: RedisType::from(r_type),
+        size: size.unwrap_or_default(),
+        ttl,
+        value: KeyValue::Unknown,
     })
 }

--- a/src/redis_client/event.rs
+++ b/src/redis_client/event.rs
@@ -1,4 +1,7 @@
+use super::types::RedisType;
+
 #[derive(Clone, Debug)]
 pub enum RedisEvent {
     FetchKeys,
+    FetchValue { key: String, r_type: RedisType },
 }

--- a/src/redis_client/runner.rs
+++ b/src/redis_client/runner.rs
@@ -101,7 +101,7 @@ impl Runner {
                         let info_res = client::redis_info(&mut manager).await;
 
                         match info_res {
-                            Ok(redis_info) => *info.lock().unwrap() = Some(redis_info),
+                            Ok(redis_info) => *info.lock() = Some(redis_info),
                             Err(_err) => {
                                 // TODO: show the popup
                             },
@@ -129,9 +129,20 @@ impl EventHandler {
 
     async fn handle(&mut self, event: RedisEvent) {
         match event {
+            RedisEvent::FetchValue { key, r_type } => {
+                match self.storage.fetch_value(&key, r_type).await {
+                    Ok(value) => {
+                        *self.state.selected_value.lock() = Some(value);
+                        self.action_hook(Action::LoadSelectedValueIntoView);
+                    }
+                    Err(err) => {
+                        log::error!("FetchValue failed for {key}: {err:?}");
+                    }
+                }
+            }
             RedisEvent::FetchKeys => {
                 let (cursor, pattern) = {
-                    let state = self.state.keyspace_state.lock().unwrap();
+                    let state = self.state.keyspace_state.lock();
 
                     (state.cursor, state.pattern.clone())
                 };
@@ -147,16 +158,16 @@ impl EventHandler {
                 match keys {
                     Ok(KeysList::Keys { cursor, keys }) => {
                         {
-                            let mut state = self.state.keyspace_state.lock().unwrap();
+                            let mut state = self.state.keyspace_state.lock();
                             state.set_next_cursor(cursor);
                         }
 
-                        let mut store = self.state.keys.lock().unwrap();
+                        let mut store = self.state.keys.lock();
                         _ = std::mem::replace(&mut *store, keys);
                         self.action_hook(Action::LoadKeysIntoKeySpace);
                     }
                     Ok(KeysList::Empty) => {
-                        let mut store = self.state.keys.lock().unwrap();
+                        let mut store = self.state.keys.lock();
                         _ = std::mem::take(&mut *store);
                         self.action_hook(Action::LoadKeysIntoKeySpace);
                     }

--- a/src/redis_client/runner.rs
+++ b/src/redis_client/runner.rs
@@ -37,12 +37,12 @@ impl Runner {
         let (tx, _) = broadcast::channel(BROADCAST_CAPACITY);
 
         Self {
-            manager,
-            info_task,
             cancelation_token,
+            manager,
+            state,
+            info_task,
             action_tx,
             tx,
-            state,
         }
     }
 
@@ -58,7 +58,7 @@ impl Runner {
 
     pub fn start(&mut self) {
         self.launch_refresh_info_task();
-        self.launch_refresh_state_task()
+        self.launch_refresh_state_task();
     }
 
     fn launch_refresh_state_task(&mut self) {
@@ -78,7 +78,7 @@ impl Runner {
                     Ok(event) = rx.recv() => {
                         event_handler.handle(event).await;
                     },
-                    _ = cancelation_token.cancelled() => {
+                    () = cancelation_token.cancelled() => {
                         break;
                     },
                 }
@@ -107,7 +107,7 @@ impl Runner {
                             },
                         }
                     },
-                    _ = cancelation_token.cancelled() => {
+                    () = cancelation_token.cancelled() => {
                         break;
                     }
                 }

--- a/src/redis_client/storage.rs
+++ b/src/redis_client/storage.rs
@@ -1,10 +1,10 @@
-use futures::future::join_all;
 use redis::aio::ConnectionManager;
 
 use super::{
-    client::fetch_meta,
-    types::{KeyMeta, KeysList},
+    client::fetch_value,
+    types::{KeyMeta, KeyValue, KeysList, RedisType},
 };
+use redis::FromRedisValue;
 
 pub struct FetchKeysWithMeta<'a> {
     manager: redis::aio::ConnectionManager,
@@ -40,7 +40,7 @@ impl<'a> FetchKeysWithMeta<'a> {
 
     pub async fn execute(mut self) -> Result<KeysList, Box<dyn std::error::Error + Sync + Send>> {
         let cursor = self.cursor.unwrap_or_default();
-        let pattern = self.pattern.unwrap_or_else(|| "*");
+        let pattern = self.pattern.unwrap_or("*");
         let (cursor, keys): (usize, Vec<String>) = redis::cmd("SCAN")
             .arg(cursor)
             .arg("MATCH")
@@ -52,12 +52,43 @@ impl<'a> FetchKeysWithMeta<'a> {
             return Ok(KeysList::Empty);
         }
 
-        let keys = join_all(keys.iter().map(|key| fetch_meta(self.manager.clone(), key)))
-            .await
-            .into_iter()
-            .collect::<Result<_, _>>()?;
+        // Single pipeline: TYPE / MEMORY USAGE / TTL for each key in the batch.
+        let mut pipe = redis::pipe();
+        for key in &keys {
+            pipe.cmd("TYPE")
+                .arg(key)
+                .cmd("MEMORY")
+                .arg("USAGE")
+                .arg(key)
+                .cmd("TTL")
+                .arg(key);
+        }
+        let raw: Vec<redis::Value> = pipe.query_async(&mut self.manager).await?;
 
-        Ok(KeysList::Keys { cursor, keys })
+        let mut metas = Vec::with_capacity(keys.len());
+        let mut iter = raw.into_iter();
+        for key in keys.into_iter() {
+            let r_type_val = iter.next().ok_or("pipeline response truncated")?;
+            let size_val = iter.next().ok_or("pipeline response truncated")?;
+            let ttl_val = iter.next().ok_or("pipeline response truncated")?;
+
+            let r_type = String::from_redis_value(r_type_val)?;
+            let size = Option::<u128>::from_redis_value(size_val)?;
+            let ttl = isize::from_redis_value(ttl_val)?;
+
+            metas.push(KeyMeta {
+                key,
+                r_type: RedisType::from(r_type),
+                size: size.unwrap_or_default(),
+                ttl,
+                value: KeyValue::Unknown,
+            });
+        }
+
+        Ok(KeysList::Keys {
+            cursor,
+            keys: metas,
+        })
     }
 }
 
@@ -73,5 +104,13 @@ impl Storage {
 
     pub fn fetch_keys_with_meta(&self) -> FetchKeysWithMeta<'_> {
         FetchKeysWithMeta::new(self.manager.clone())
+    }
+
+    pub async fn fetch_value(
+        &self,
+        key: &str,
+        r_type: RedisType,
+    ) -> Result<KeyValue, Box<dyn std::error::Error + Sync + Send>> {
+        fetch_value(self.manager.clone(), key, r_type).await
     }
 }

--- a/src/redis_client/storage.rs
+++ b/src/redis_client/storage.rs
@@ -1,43 +1,45 @@
 use redis::aio::ConnectionManager;
+use redis::FromRedisValue;
 
 use super::{
     client::fetch_value,
     types::{KeyMeta, KeyValue, KeysList, RedisType},
 };
-use redis::FromRedisValue;
 
 pub struct FetchKeysWithMeta<'a> {
-    manager: redis::aio::ConnectionManager,
-    size: Option<usize>,
+    manager: ConnectionManager,
     cursor: Option<usize>,
     pattern: Option<&'a str>,
 }
 
 impl<'a> FetchKeysWithMeta<'a> {
-    pub fn new(manager: redis::aio::ConnectionManager) -> Self {
+    pub fn new(manager: ConnectionManager) -> Self {
         Self {
             manager,
             cursor: None,
             pattern: None,
-            size: None,
         }
     }
 
-    pub fn size(mut self, size: Option<usize>) -> Self {
-        self.size = size;
-        self
-    }
-
+    #[must_use]
     pub fn cursor(mut self, cursor: Option<usize>) -> Self {
         self.cursor = cursor;
         self
     }
 
+    #[must_use]
     pub fn pattern(mut self, pattern: Option<&'a str>) -> Self {
         self.pattern = pattern;
         self
     }
 
+    /// Run a single SCAN followed by a TYPE / MEMORY USAGE / TTL
+    /// pipeline for every key in the batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if SCAN fails, the pipeline fails, or any
+    /// pipeline reply has an unexpected shape.
     pub async fn execute(mut self) -> Result<KeysList, Box<dyn std::error::Error + Sync + Send>> {
         let cursor = self.cursor.unwrap_or_default();
         let pattern = self.pattern.unwrap_or("*");
@@ -67,7 +69,7 @@ impl<'a> FetchKeysWithMeta<'a> {
 
         let mut metas = Vec::with_capacity(keys.len());
         let mut iter = raw.into_iter();
-        for key in keys.into_iter() {
+        for key in keys {
             let r_type_val = iter.next().ok_or("pipeline response truncated")?;
             let size_val = iter.next().ok_or("pipeline response truncated")?;
             let ttl_val = iter.next().ok_or("pipeline response truncated")?;
@@ -106,6 +108,11 @@ impl Storage {
         FetchKeysWithMeta::new(self.manager.clone())
     }
 
+    /// Fetch the value for a key. Delegates to [`fetch_value`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying Redis command fails.
     pub async fn fetch_value(
         &self,
         key: &str,

--- a/src/redis_client/types.rs
+++ b/src/redis_client/types.rs
@@ -63,6 +63,7 @@ pub enum KeyValue {
     Set(HashSet<String>),
     Hash(HashMap<String, String>),
     Zset(Vec<(String, f64)>), // Tuple of value and score
+    #[allow(dead_code)]
     Json(serde_json::Value),
     Unknown,
 }
@@ -73,6 +74,7 @@ pub struct KeyMeta {
     pub r_type: RedisType,
     pub size: u128,
     pub ttl: isize,
+    #[allow(dead_code)]
     pub value: KeyValue,
 }
 
@@ -93,8 +95,8 @@ pub enum RedisType {
 }
 
 impl RedisType {
-    fn from_str<'a>(value: Cow<'a, str>) -> Self {
-        match value.as_ref() {
+    fn from_str(value: &str) -> Self {
+        match value {
             "string" => Self::String,
             "hash" => Self::Hash,
             "set" => Self::Set,
@@ -106,18 +108,17 @@ impl RedisType {
     }
 }
 
-impl<'a> Into<Text<'a>> for RedisType {
-    fn into(self) -> Text<'a> {
-        match self {
-            Self::String => Span::raw(" STRING ")
-                .bg(config::get().keyspace.string)
-                .into(),
-            Self::Json => Span::raw(" JSON ").bg(config::get().keyspace.json).into(),
-            Self::List => Span::raw(" LIST ").bg(config::get().keyspace.list).into(),
-            Self::Set => Span::raw(" SET ").bg(config::get().keyspace.set).into(),
-            Self::Zset => Span::raw(" ZSET ").bg(config::get().keyspace.zset).into(),
-            Self::Hash => Span::raw(" HASH ").bg(config::get().keyspace.hash).into(),
-            Self::Unknown => Span::raw(" ? ").bg(config::get().keyspace.unknown).into(),
+impl From<RedisType> for Text<'_> {
+    fn from(value: RedisType) -> Self {
+        let palette = &config::get().keyspace;
+        match value {
+            RedisType::String => Span::raw(" STRING ").bg(palette.string).into(),
+            RedisType::Json => Span::raw(" JSON ").bg(palette.json).into(),
+            RedisType::List => Span::raw(" LIST ").bg(palette.list).into(),
+            RedisType::Set => Span::raw(" SET ").bg(palette.set).into(),
+            RedisType::Zset => Span::raw(" ZSET ").bg(palette.zset).into(),
+            RedisType::Hash => Span::raw(" HASH ").bg(palette.hash).into(),
+            RedisType::Unknown => Span::raw(" ? ").bg(palette.unknown).into(),
         }
     }
 }
@@ -128,7 +129,7 @@ where
 {
     #[inline]
     fn from(value: T) -> Self {
-        Self::from_str(value.into())
+        Self::from_str(value.into().as_ref())
     }
 }
 
@@ -137,6 +138,7 @@ pub struct KeyspaceState {
     pub cursor: Option<usize>,
     pub next_cursor: Option<usize>,
     pub pattern: Option<String>,
+    #[allow(dead_code)]
     pub count: usize,
     pub cursor_stack: VecDeque<usize>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,12 +1,15 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use crate::redis_client::types::{KeyMeta, KeyspaceState, RedisInfo};
+use parking_lot::Mutex;
+
+use crate::redis_client::types::{KeyMeta, KeyValue, KeyspaceState, RedisInfo};
 
 #[derive(Clone, Debug)]
 pub struct SharedState {
     pub info: Arc<Mutex<Option<RedisInfo>>>,
     pub keys: Arc<Mutex<Vec<KeyMeta>>>,
     pub keyspace_state: Arc<Mutex<KeyspaceState>>,
+    pub selected_value: Arc<Mutex<Option<KeyValue>>>,
 }
 
 impl Default for SharedState {
@@ -15,6 +18,7 @@ impl Default for SharedState {
             info: Arc::new(Mutex::new(None)),
             keys: Arc::new(Mutex::new(Vec::new())),
             keyspace_state: Arc::new(Mutex::new(KeyspaceState::default())),
+            selected_value: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -60,7 +60,7 @@ pub struct Tui {
 impl Tui {
     pub fn new() -> Result<Self> {
         let tick_rate = 4.0;
-        let frame_rate = 60.0;
+        let frame_rate = 10.0;
         let terminal = ratatui::Terminal::new(Backend::new(io()))?;
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let cancellation_token = CancellationToken::new();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -58,6 +58,12 @@ pub struct Tui {
 }
 
 impl Tui {
+    /// Build a new TUI wrapping a crossterm-backed terminal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ratatui terminal cannot be constructed
+    /// (typically a stdout I/O failure).
     pub fn new() -> Result<Self> {
         let tick_rate = 4.0;
         let frame_rate = 10.0;
@@ -81,26 +87,33 @@ impl Tui {
         })
     }
 
+    #[must_use]
     pub fn tick_rate(mut self, tick_rate: f64) -> Self {
         self.tick_rate = tick_rate;
         self
     }
 
+    #[must_use]
     pub fn frame_rate(mut self, frame_rate: f64) -> Self {
         self.frame_rate = frame_rate;
         self
     }
 
+    #[must_use]
     pub fn cancelation_token(mut self, token: CancellationToken) -> Self {
         self.cancellation_token = token;
         self
     }
 
+    #[must_use]
+    #[allow(dead_code)]
     pub fn mouse(mut self, mouse: bool) -> Self {
         self.mouse = mouse;
         self
     }
 
+    #[must_use]
+    #[allow(dead_code)]
     pub fn paste(mut self, paste: bool) -> Self {
         self.paste = paste;
         self
@@ -126,7 +139,7 @@ impl Tui {
                 let render_delay = render_interval.tick();
                 let crossterm_event = reader.next().fuse();
                 tokio::select! {
-                  _ = tui_cancelation_token.cancelled() => {
+                  () = tui_cancelation_token.cancelled() => {
                     break;
                   }
                   maybe_event = crossterm_event => {
@@ -172,7 +185,7 @@ impl Tui {
         });
     }
 
-    pub fn stop(&self) -> Result<()> {
+    pub fn stop(&self) {
         self.cancel();
         let mut counter = 0;
         while !self.event_task.is_finished() {
@@ -186,9 +199,14 @@ impl Tui {
                 break;
             }
         }
-        Ok(())
     }
 
+    /// Enter the alternate screen, enable raw mode, and spawn the
+    /// terminal event task.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a crossterm terminal command fails.
     pub fn enter(&mut self) -> Result<()> {
         crossterm::terminal::enable_raw_mode()?;
         crossterm::execute!(io(), EnterAlternateScreen, cursor::Hide)?;
@@ -202,8 +220,13 @@ impl Tui {
         Ok(())
     }
 
+    /// Tear down the alternate screen and disable raw mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a crossterm terminal command fails.
     pub fn exit(&mut self) -> Result<()> {
-        self.stop()?;
+        self.stop();
         if crossterm::terminal::is_raw_mode_enabled()? {
             self.flush()?;
             if self.paste {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use color_eyre::eyre::{eyre, Result};
 use directories::ProjectDirs;
-use lazy_static::lazy_static;
 use tracing::error;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
@@ -19,24 +18,38 @@ const VERSION_MESSAGE: &str = concat!(
 );
 
 // TODO: get rid of the lazy_static. Replace with a native OnceLock/OnceCell
-lazy_static! {
-    pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase().to_string();
-    pub static ref DATA_FOLDER: Option<PathBuf> =
-        std::env::var(format!("{}_DATA", PROJECT_NAME.clone()))
-            .ok()
-            .map(PathBuf::from);
-    pub static ref CONFIG_FOLDER: Option<PathBuf> =
-        std::env::var(format!("{}_CONFIG", PROJECT_NAME.clone()))
-            .ok()
-            .map(PathBuf::from);
-    pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", PROJECT_NAME.clone());
-    pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
+#[allow(clippy::ref_option)]
+mod statics {
+    use super::PathBuf;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase();
+        pub static ref DATA_FOLDER: Option<PathBuf> =
+            std::env::var(format!("{}_DATA", PROJECT_NAME.as_str()))
+                .ok()
+                .map(PathBuf::from);
+        pub static ref CONFIG_FOLDER: Option<PathBuf> =
+            std::env::var(format!("{}_CONFIG", PROJECT_NAME.as_str()))
+                .ok()
+                .map(PathBuf::from);
+        pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", PROJECT_NAME.as_str());
+        pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
+    }
 }
+
+pub use statics::{CONFIG_FOLDER, DATA_FOLDER, LOG_ENV, LOG_FILE};
 
 fn project_directory() -> Option<ProjectDirs> {
     ProjectDirs::from("com", "kdheepak", env!("CARGO_PKG_NAME"))
 }
 
+/// Install panic + eyre hooks that tear down the TUI and emit a
+/// human-readable crash report.
+///
+/// # Errors
+///
+/// Returns an error if the eyre hook cannot be installed.
 pub fn initialize_panic_handler() -> Result<()> {
     let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default()
         .panic_section(format!(
@@ -51,7 +64,7 @@ pub fn initialize_panic_handler() -> Result<()> {
     std::panic::set_hook(Box::new(move |panic_info| {
         if let Ok(mut t) = crate::tui::Tui::new() {
             if let Err(r) = t.exit() {
-                error!("Unable to exit Terminal: {:?}", r);
+                error!("Unable to exit Terminal: {r:?}");
             }
         }
 
@@ -72,7 +85,7 @@ pub fn initialize_panic_handler() -> Result<()> {
             eprintln!("{}", panic_hook.panic_report(panic_info)); // prints color-eyre stack trace to stderr
         }
         let msg = format!("{}", panic_hook.panic_report(panic_info));
-        log::error!("Error: {}", strip_ansi_escapes::strip_str(msg));
+        log::error!("Error: {error}", error = strip_ansi_escapes::strip_str(msg));
 
         #[cfg(debug_assertions)]
         {
@@ -111,15 +124,21 @@ pub fn get_config_dir() -> PathBuf {
     directory
 }
 
+/// Initialise the file-based tracing subscriber under the data directory.
+///
+/// # Errors
+///
+/// Returns an error if the data directory cannot be created or the log
+/// file cannot be opened for writing.
 pub fn initialize_logging() -> Result<()> {
     let directory = get_data_dir();
-    std::fs::create_dir_all(directory.clone())?;
-    let log_path = directory.join(LOG_FILE.clone());
+    std::fs::create_dir_all(&directory)?;
+    let log_path = directory.join(LOG_FILE.as_str());
     let log_file = std::fs::File::create(log_path)?;
     std::env::set_var(
         "RUST_LOG",
         std::env::var("RUST_LOG")
-            .or_else(|_| std::env::var(LOG_ENV.clone()))
+            .or_else(|_| std::env::var(LOG_ENV.as_str()))
             .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
     );
     let file_subscriber = tracing_subscriber::fmt::layer()
@@ -168,6 +187,10 @@ macro_rules! trace_dbg {
 ///   redis://[user@]host:port[/db]   → redis://:token@host:port[/db]
 ///   rediss://...                     → same, TLS variant
 ///   redis+unix://...                 → same, Unix socket variant
+///
+/// # Errors
+///
+/// Returns an error if `url` is missing a `://` separator.
 pub fn inject_token(url: &str, token: &str) -> Result<String> {
     let scheme_end = url
         .find("://")

--- a/src/widgets/info.rs
+++ b/src/widgets/info.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use ratatui::{prelude::*, widgets::*};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{self, Alignment, Constraint, Layout, Rect};
+use ratatui::style::Stylize;
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph, StatefulWidget, Widget};
 
 use crate::{config, redis_client::types::RedisInfo};
 

--- a/src/widgets/info.rs
+++ b/src/widgets/info.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use ratatui::{prelude::*, widgets::*};
 
@@ -20,16 +22,17 @@ impl StatefulWidget for InfoWidget {
     type State = Info;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let cfg = config::get();
         Block::new()
-            .fg(config::get().colors.base04)
-            .bg(config::get().colors.base00)
+            .fg(cfg.colors.base04)
+            .bg(cfg.colors.base00)
             .borders(Borders::ALL)
             .title("Info")
             .title_alignment(Alignment::Left)
             .border_type(BorderType::Rounded)
             .render(area, buf);
 
-        let common_info = { state.info.lock().unwrap().as_ref().map(Clone::clone) };
+        let common_info = { state.info.lock().as_ref().map(Clone::clone) };
 
         let [top, bottom] = Layout::vertical([Constraint::Length(1), Constraint::Length(1)])
             .flex(layout::Flex::Center)

--- a/src/widgets/keyspace.rs
+++ b/src/widgets/keyspace.rs
@@ -322,6 +322,7 @@ const HIGHLIGHT_SYMBOL: &str = " >> ";
 impl StatefulWidget for KeySpaceWidget {
     type State = KeySpace;
 
+    #[allow(clippy::too_many_lines)]
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let cfg = config::get();
         let [t_area, view_area] =

--- a/src/widgets/keyspace.rs
+++ b/src/widgets/keyspace.rs
@@ -251,7 +251,12 @@ impl KeySpaceWidget {
         }
     }
 
-    fn render_single_column_table(header_label: &str, rows_data: &[String], area: Rect, buf: &mut Buffer) {
+    fn render_single_column_table(
+        header_label: &str,
+        rows_data: &[String],
+        area: Rect,
+        buf: &mut Buffer,
+    ) {
         let cfg = config::get();
         let mut table_state = TableState::default();
         let widths = [Constraint::Percentage(100)];
@@ -286,11 +291,14 @@ impl KeySpaceWidget {
         let cfg = config::get();
         let mut table_state = TableState::default();
         let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
-        let header = Row::new([Cell::from(left_label.bold()), Cell::from(right_label.bold())])
-            .top_margin(1)
-            .bottom_margin(1)
-            .fg(cfg.colors.base04)
-            .bg(cfg.colors.base02);
+        let header = Row::new([
+            Cell::from(left_label.bold()),
+            Cell::from(right_label.bold()),
+        ])
+        .top_margin(1)
+        .bottom_margin(1)
+        .fg(cfg.colors.base04)
+        .bg(cfg.colors.base02);
 
         let rows = rows_data.iter().map(|(left, right)| {
             Row::new([Cell::from(left.as_str()), Cell::from(right.as_str())])
@@ -363,10 +371,13 @@ impl StatefulWidget for KeySpaceWidget {
             .flex(ratatui::layout::Flex::Center)
             .areas(cursor_size_are);
 
-        Paragraph::new(format!("Cursor: {cursor}", cursor = state.cursor.unwrap_or_default()))
-            .bold()
-            .alignment(Alignment::Left)
-            .render(cursor_area, buf);
+        Paragraph::new(format!(
+            "Cursor: {cursor}",
+            cursor = state.cursor.unwrap_or_default()
+        ))
+        .bold()
+        .alignment(Alignment::Left)
+        .render(cursor_area, buf);
 
         Paragraph::new("Size: 10")
             .bold()

--- a/src/widgets/keyspace.rs
+++ b/src/widgets/keyspace.rs
@@ -211,7 +211,9 @@ impl KeySpaceWidget {
             key.key,
             key.r_type,
             key.ttl,
-            Byte::from_u128(key.size).unwrap_or_default().get_appropriate_unit(UnitType::Binary)
+            Byte::from_u128(key.size)
+                .unwrap_or_default()
+                .get_appropriate_unit(UnitType::Binary)
         );
 
         Paragraph::new(key_info)

--- a/src/widgets/keyspace.rs
+++ b/src/widgets/keyspace.rs
@@ -31,6 +31,7 @@ pub struct KeySpace {
     pattern: Option<String>,
     mode: KeySpaceMode,
     text_area: Option<TextArea<'static>>,
+    selected_value: Option<KeyValue>,
 }
 
 impl KeySpace {
@@ -42,7 +43,22 @@ impl KeySpace {
             pattern: None,
             mode: KeySpaceMode::Normal,
             text_area: None,
+            selected_value: None,
         }
+    }
+
+    pub fn selected_key(&self) -> Option<(String, RedisType)> {
+        let idx = self.table.selected()?;
+        let meta = self.keys.get(idx)?;
+        Some((meta.key.clone(), meta.r_type))
+    }
+
+    pub fn set_selected_value(&mut self, value: Option<KeyValue>) {
+        self.selected_value = value;
+    }
+
+    pub fn clear_selected_value(&mut self) {
+        self.selected_value = None;
     }
 
     pub fn is_popup(&self) -> bool {
@@ -56,12 +72,13 @@ impl KeySpace {
     }
 
     pub fn enter_filter_pattern(&mut self) {
+        let cfg = config::get();
         self.mode = KeySpaceMode::Popup(KeySpacePopupMode::FilterPattern);
         let mut text_area = TextArea::default();
         text_area.set_placeholder_text("Enter pattern");
         text_area.set_block(
             Block::default()
-                .border_style(config::get().colors.base04)
+                .border_style(cfg.colors.base04)
                 .border_type(BorderType::Rounded)
                 .borders(Borders::ALL)
                 .title("Pattern"),
@@ -167,6 +184,7 @@ impl KeySpaceWidget {
         area: ratatui::prelude::Rect,
         buf: &mut ratatui::prelude::Buffer,
     ) {
+        let cfg = config::get();
         let Some(selected_index) = state.table.selected() else {
             return;
         };
@@ -193,113 +211,120 @@ impl KeySpaceWidget {
             key.key,
             key.r_type,
             key.ttl,
-            unsafe { Byte::from_u128_unsafe(key.size) }.get_appropriate_unit(UnitType::Binary)
+            Byte::from_u128(key.size).unwrap_or_default().get_appropriate_unit(UnitType::Binary)
         );
 
         Paragraph::new(key_info)
             .wrap(Wrap { trim: true })
             .render(key_meta_area, buf);
 
-        match key.value {
-            KeyValue::String(ref value) => {
+        let Some(ref loaded_value) = state.selected_value else {
+            Paragraph::new("Loading…")
+                .wrap(Wrap { trim: true })
+                .render(view_area, buf);
+            return;
+        };
+
+        match loaded_value {
+            KeyValue::String(value) => {
                 Paragraph::new(format!("Value: {}", value))
                     .wrap(Wrap { trim: true })
                     .render(view_area, buf);
             }
-            KeyValue::List(ref value) => {
+            KeyValue::List(value) => {
                 let mut table_state = TableState::default();
 
                 let widths = [Constraint::Percentage(100)];
                 let header: Row<'_> = Row::new(["Item"].map(|h| Cell::from(h.bold())))
                     .top_margin(1)
                     .bottom_margin(1)
-                    .fg(config::get().colors.base04)
-                    .bg(config::get().colors.base02);
+                    .fg(cfg.colors.base04)
+                    .bg(cfg.colors.base02);
 
-                let rows = value.iter().cloned().map(|(value)| {
-                    Row::new([Cell::from(value)])
-                        .fg(config::get().colors.base04)
-                        .bg(config::get().colors.base00)
+                let rows = value.iter().map(|item| {
+                    Row::new([Cell::from(item.as_str())])
+                        .fg(cfg.colors.base04)
+                        .bg(cfg.colors.base00)
                 });
                 let table: Table<'_> = Table::new(rows, widths)
                     .header(header)
                     .flex(ratatui::layout::Flex::Center)
                     .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(config::get().colors.base05)
+                    .highlight_style(cfg.colors.base05)
                     .highlight_spacing(HighlightSpacing::Always);
 
                 StatefulWidget::render(table, view_area, buf, &mut table_state);
             }
-            KeyValue::Hash(ref value) => {
+            KeyValue::Hash(value) => {
                 let mut table_state = TableState::default();
 
                 let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
                 let header: Row<'_> = Row::new(["Field", "Value"].map(|h| Cell::from(h.bold())))
                     .top_margin(1)
                     .bottom_margin(1)
-                    .fg(config::get().colors.base04)
-                    .bg(config::get().colors.base02);
+                    .fg(cfg.colors.base04)
+                    .bg(cfg.colors.base02);
 
-                let rows = value.iter().map(|(field, value)| {
-                    Row::new([Cell::from(field.clone()), Cell::from(value.clone())])
-                        .fg(config::get().colors.base04)
-                        .bg(config::get().colors.base00)
+                let rows = value.iter().map(|(field, val)| {
+                    Row::new([Cell::from(field.as_str()), Cell::from(val.as_str())])
+                        .fg(cfg.colors.base04)
+                        .bg(cfg.colors.base00)
                 });
                 let table: Table<'_> = Table::new(rows, widths)
                     .header(header)
                     .widths(widths)
                     .flex(ratatui::layout::Flex::Center)
                     .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(config::get().colors.base05)
+                    .highlight_style(cfg.colors.base05)
                     .highlight_spacing(HighlightSpacing::Always);
 
                 StatefulWidget::render(table, view_area, buf, &mut table_state);
             }
-            KeyValue::Set(ref value) => {
+            KeyValue::Set(value) => {
                 let mut table_state = TableState::default();
 
                 let widths = [Constraint::Percentage(100)];
                 let header: Row<'_> = Row::new(["Member"].map(|h| Cell::from(h.bold())))
                     .top_margin(1)
                     .bottom_margin(1)
-                    .fg(config::get().colors.base04)
-                    .bg(config::get().colors.base02);
+                    .fg(cfg.colors.base04)
+                    .bg(cfg.colors.base02);
 
-                let rows = value.iter().cloned().map(|member| {
-                    Row::new([Cell::from(member)])
-                        .fg(config::get().colors.base04)
-                        .bg(config::get().colors.base00)
+                let rows = value.iter().map(|member| {
+                    Row::new([Cell::from(member.as_str())])
+                        .fg(cfg.colors.base04)
+                        .bg(cfg.colors.base00)
                 });
                 let table: Table<'_> = Table::new(rows, widths)
                     .header(header)
                     .flex(ratatui::layout::Flex::Center)
                     .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(config::get().colors.base05)
+                    .highlight_style(cfg.colors.base05)
                     .highlight_spacing(HighlightSpacing::Always);
 
                 StatefulWidget::render(table, view_area, buf, &mut table_state);
             }
-            KeyValue::Zset(ref value) => {
+            KeyValue::Zset(value) => {
                 let mut table_state = TableState::default();
 
                 let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
                 let header: Row<'_> = Row::new(["Member", "Score"].map(|h| Cell::from(h.bold())))
                     .top_margin(1)
                     .bottom_margin(1)
-                    .fg(config::get().colors.base04)
-                    .bg(config::get().colors.base02);
+                    .fg(cfg.colors.base04)
+                    .bg(cfg.colors.base02);
 
                 let rows = value.iter().map(|(member, score)| {
-                    Row::new([Cell::from(member.clone()), Cell::from(score.to_string())])
-                        .fg(config::get().colors.base04)
-                        .bg(config::get().colors.base00)
+                    Row::new([Cell::from(member.as_str()), Cell::from(score.to_string())])
+                        .fg(cfg.colors.base04)
+                        .bg(cfg.colors.base00)
                 });
                 let table: Table<'_> = Table::new(rows, widths)
                     .header(header)
                     .widths(widths)
                     .flex(ratatui::layout::Flex::Center)
                     .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(config::get().colors.base05)
+                    .highlight_style(cfg.colors.base05)
                     .highlight_spacing(HighlightSpacing::Always);
 
                 StatefulWidget::render(table, view_area, buf, &mut table_state);
@@ -320,14 +345,15 @@ impl StatefulWidget for KeySpaceWidget {
         buf: &mut ratatui::prelude::Buffer,
         state: &mut Self::State,
     ) {
+        let cfg = config::get();
         let [t_area, view_area] =
             Layout::horizontal([Constraint::Percentage(35), Constraint::Fill(1)])
                 .flex(ratatui::layout::Flex::Center)
                 .areas(area);
 
         let space_block = Block::new()
-            .bg(config::get().colors.base00)
-            .fg(config::get().colors.base04)
+            .bg(cfg.colors.base00)
+            .fg(cfg.colors.base04)
             .border_type(ratatui::widgets::BorderType::Rounded)
             .borders(Borders::all())
             .title("Keys");
@@ -336,8 +362,8 @@ impl StatefulWidget for KeySpaceWidget {
         space_block.render(t_area, buf);
 
         Block::new()
-            .bg(config::get().colors.base00)
-            .fg(config::get().colors.base04)
+            .bg(cfg.colors.base00)
+            .fg(cfg.colors.base04)
             .border_type(ratatui::widgets::BorderType::Rounded)
             .borders(Borders::all())
             .title("Values")
@@ -349,8 +375,8 @@ impl StatefulWidget for KeySpaceWidget {
             .areas(table_area);
 
         let filters_block = Block::new()
-            .bg(config::get().colors.base00)
-            .fg(config::get().colors.base04)
+            .bg(cfg.colors.base00)
+            .fg(cfg.colors.base04)
             .border_type(ratatui::widgets::BorderType::Rounded)
             .borders(Borders::all())
             .title("Filters");
@@ -396,37 +422,34 @@ impl StatefulWidget for KeySpaceWidget {
             Row::new(["Type", "Key", "TTL(s)", "Size"].map(|h| Cell::from(h.bold())))
                 .top_margin(1)
                 .bottom_margin(1)
-                .fg(config::get().colors.base04)
-                .bg(config::get().colors.base02);
+                .fg(cfg.colors.base04)
+                .bg(cfg.colors.base02);
 
-        let rows = state
-            .keys
-            .clone()
-            .into_iter()
-            .enumerate()
-            .map(|(idx, meta)| {
-                Row::new([
-                    Cell::from(RedisType::from(meta.r_type)),
-                    Cell::from(meta.key),
-                    Cell::from(meta.ttl.to_string()),
-                    Cell::from(format!(
-                        "{:.2}",
-                        unsafe { Byte::from_u128_unsafe(meta.size) }
-                            .get_appropriate_unit(UnitType::Binary)
-                    )),
-                ])
-                .fg(config::get().colors.base04)
-                .bg(if idx % 2 == 0 {
-                    config::get().colors.base00
-                } else {
-                    config::get().colors.base01
-                })
-            });
+        let rows = state.keys.iter().enumerate().map(|(idx, meta)| {
+            let badge: ratatui::text::Text = meta.r_type.into();
+            Row::new([
+                Cell::from(badge),
+                Cell::from(meta.key.as_str()),
+                Cell::from(meta.ttl.to_string()),
+                Cell::from(format!(
+                    "{:.2}",
+                    Byte::from_u128(meta.size)
+                        .unwrap_or_default()
+                        .get_appropriate_unit(UnitType::Binary)
+                )),
+            ])
+            .fg(cfg.colors.base04)
+            .bg(if idx % 2 == 0 {
+                cfg.colors.base00
+            } else {
+                cfg.colors.base01
+            })
+        });
         let table: Table<'_> = Table::new(rows, widths)
             .header(header)
             .flex(ratatui::layout::Flex::Center)
             .highlight_symbol(HIGHLIGHT_SYMBOL)
-            .highlight_style(config::get().colors.base05)
+            .highlight_style(cfg.colors.base05)
             .highlight_spacing(HighlightSpacing::Always);
 
         StatefulWidget::render(table, table_area, buf, &mut state.table);

--- a/src/widgets/keyspace.rs
+++ b/src/widgets/keyspace.rs
@@ -1,11 +1,12 @@
 use byte_unit::{Byte, UnitType};
 use crossterm::event::KeyEvent;
 use ratatui::{
-    layout::{Alignment, Constraint, Layout, Margin},
+    buffer::Buffer,
+    layout::{Alignment, Constraint, Layout, Rect},
     style::Stylize,
     widgets::{
-        Block, BorderType, Borders, Cell, Clear, HighlightSpacing, Paragraph, Row, StatefulWidget,
-        Table, TableState, Widget, Wrap,
+        Block, BorderType, Borders, Cell, HighlightSpacing, Paragraph, Row, StatefulWidget, Table,
+        TableState, Widget, Wrap,
     },
 };
 use tui_textarea::TextArea;
@@ -91,7 +92,7 @@ impl KeySpace {
         let pattern = if let Some(text_area) = self.text_area.take() {
             let line = text_area.lines()[0].clone();
 
-            if line == "" {
+            if line.is_empty() {
                 self.pattern = None;
             } else {
                 self.pattern = Some(line.clone());
@@ -141,7 +142,7 @@ impl KeySpace {
 
     fn scroll_to(&mut self, index: usize) {
         if self.keys.is_empty() {
-            self.table.select(None)
+            self.table.select(None);
         } else {
             self.table.select(Some(index));
         }
@@ -151,12 +152,7 @@ impl KeySpace {
 pub struct KeySpaceWidget;
 
 impl KeySpaceWidget {
-    fn render_confirm_popup(
-        &self,
-        state: &mut KeySpace,
-        area: ratatui::prelude::Rect,
-        buf: &mut ratatui::prelude::Buffer,
-    ) {
+    fn render_confirm_popup(state: &mut KeySpace, area: Rect, buf: &mut Buffer) {
         let [_, popup_area, _] = Layout::vertical([
             Constraint::Percentage(40),
             Constraint::Min(3),
@@ -178,17 +174,10 @@ impl KeySpaceWidget {
         }
     }
 
-    fn render_key_view(
-        &self,
-        state: &mut KeySpace,
-        area: ratatui::prelude::Rect,
-        buf: &mut ratatui::prelude::Buffer,
-    ) {
-        let cfg = config::get();
+    fn render_key_view(state: &mut KeySpace, area: Rect, buf: &mut Buffer) {
         let Some(selected_index) = state.table.selected() else {
             return;
         };
-
         let Some(key) = state.keys.get(selected_index) else {
             return;
         };
@@ -207,11 +196,11 @@ impl KeySpaceWidget {
                 .areas(key_details_area);
 
         let key_info = format!(
-            "Key: {}\nType: {:?}\nTTL: {}\nSize: {}",
-            key.key,
-            key.r_type,
-            key.ttl,
-            Byte::from_u128(key.size)
+            "Key: {key}\nType: {ty:?}\nTTL: {ttl}\nSize: {size}",
+            key = key.key,
+            ty = key.r_type,
+            ttl = key.ttl,
+            size = Byte::from_u128(key.size)
                 .unwrap_or_default()
                 .get_appropriate_unit(UnitType::Binary)
         );
@@ -220,119 +209,103 @@ impl KeySpaceWidget {
             .wrap(Wrap { trim: true })
             .render(key_meta_area, buf);
 
-        let Some(ref loaded_value) = state.selected_value else {
+        let Some(loaded_value) = state.selected_value.as_ref() else {
             Paragraph::new("Loading…")
                 .wrap(Wrap { trim: true })
                 .render(view_area, buf);
             return;
         };
 
-        match loaded_value {
-            KeyValue::String(value) => {
-                Paragraph::new(format!("Value: {}", value))
+        Self::render_value(loaded_value, view_area, buf);
+    }
+
+    fn render_value(value: &KeyValue, area: Rect, buf: &mut Buffer) {
+        match value {
+            KeyValue::String(s) => {
+                Paragraph::new(format!("Value: {s}"))
                     .wrap(Wrap { trim: true })
-                    .render(view_area, buf);
+                    .render(area, buf);
             }
-            KeyValue::List(value) => {
-                let mut table_state = TableState::default();
-
-                let widths = [Constraint::Percentage(100)];
-                let header: Row<'_> = Row::new(["Item"].map(|h| Cell::from(h.bold())))
-                    .top_margin(1)
-                    .bottom_margin(1)
-                    .fg(cfg.colors.base04)
-                    .bg(cfg.colors.base02);
-
-                let rows = value.iter().map(|item| {
-                    Row::new([Cell::from(item.as_str())])
-                        .fg(cfg.colors.base04)
-                        .bg(cfg.colors.base00)
-                });
-                let table: Table<'_> = Table::new(rows, widths)
-                    .header(header)
-                    .flex(ratatui::layout::Flex::Center)
-                    .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(cfg.colors.base05)
-                    .highlight_spacing(HighlightSpacing::Always);
-
-                StatefulWidget::render(table, view_area, buf, &mut table_state);
+            KeyValue::List(items) => Self::render_single_column_table("Item", items, area, buf),
+            KeyValue::Set(members) => Self::render_single_column_table(
+                "Member",
+                members.iter().cloned().collect::<Vec<_>>().as_slice(),
+                area,
+                buf,
+            ),
+            KeyValue::Hash(entries) => {
+                let pairs: Vec<(String, String)> = entries
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                Self::render_two_column_table("Field", "Value", &pairs, area, buf);
             }
-            KeyValue::Hash(value) => {
-                let mut table_state = TableState::default();
-
-                let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
-                let header: Row<'_> = Row::new(["Field", "Value"].map(|h| Cell::from(h.bold())))
-                    .top_margin(1)
-                    .bottom_margin(1)
-                    .fg(cfg.colors.base04)
-                    .bg(cfg.colors.base02);
-
-                let rows = value.iter().map(|(field, val)| {
-                    Row::new([Cell::from(field.as_str()), Cell::from(val.as_str())])
-                        .fg(cfg.colors.base04)
-                        .bg(cfg.colors.base00)
-                });
-                let table: Table<'_> = Table::new(rows, widths)
-                    .header(header)
-                    .widths(widths)
-                    .flex(ratatui::layout::Flex::Center)
-                    .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(cfg.colors.base05)
-                    .highlight_spacing(HighlightSpacing::Always);
-
-                StatefulWidget::render(table, view_area, buf, &mut table_state);
+            KeyValue::Zset(entries) => {
+                let pairs: Vec<(String, String)> = entries
+                    .iter()
+                    .map(|(member, score)| (member.clone(), score.to_string()))
+                    .collect();
+                Self::render_two_column_table("Member", "Score", &pairs, area, buf);
             }
-            KeyValue::Set(value) => {
-                let mut table_state = TableState::default();
-
-                let widths = [Constraint::Percentage(100)];
-                let header: Row<'_> = Row::new(["Member"].map(|h| Cell::from(h.bold())))
-                    .top_margin(1)
-                    .bottom_margin(1)
-                    .fg(cfg.colors.base04)
-                    .bg(cfg.colors.base02);
-
-                let rows = value.iter().map(|member| {
-                    Row::new([Cell::from(member.as_str())])
-                        .fg(cfg.colors.base04)
-                        .bg(cfg.colors.base00)
-                });
-                let table: Table<'_> = Table::new(rows, widths)
-                    .header(header)
-                    .flex(ratatui::layout::Flex::Center)
-                    .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(cfg.colors.base05)
-                    .highlight_spacing(HighlightSpacing::Always);
-
-                StatefulWidget::render(table, view_area, buf, &mut table_state);
-            }
-            KeyValue::Zset(value) => {
-                let mut table_state = TableState::default();
-
-                let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
-                let header: Row<'_> = Row::new(["Member", "Score"].map(|h| Cell::from(h.bold())))
-                    .top_margin(1)
-                    .bottom_margin(1)
-                    .fg(cfg.colors.base04)
-                    .bg(cfg.colors.base02);
-
-                let rows = value.iter().map(|(member, score)| {
-                    Row::new([Cell::from(member.as_str()), Cell::from(score.to_string())])
-                        .fg(cfg.colors.base04)
-                        .bg(cfg.colors.base00)
-                });
-                let table: Table<'_> = Table::new(rows, widths)
-                    .header(header)
-                    .widths(widths)
-                    .flex(ratatui::layout::Flex::Center)
-                    .highlight_symbol(HIGHLIGHT_SYMBOL)
-                    .highlight_style(cfg.colors.base05)
-                    .highlight_spacing(HighlightSpacing::Always);
-
-                StatefulWidget::render(table, view_area, buf, &mut table_state);
-            }
-            _ => {}
+            KeyValue::Json(_) | KeyValue::Unknown => {}
         }
+    }
+
+    fn render_single_column_table(header_label: &str, rows_data: &[String], area: Rect, buf: &mut Buffer) {
+        let cfg = config::get();
+        let mut table_state = TableState::default();
+        let widths = [Constraint::Percentage(100)];
+        let header = Row::new([Cell::from(header_label.bold())])
+            .top_margin(1)
+            .bottom_margin(1)
+            .fg(cfg.colors.base04)
+            .bg(cfg.colors.base02);
+
+        let rows = rows_data.iter().map(|item| {
+            Row::new([Cell::from(item.as_str())])
+                .fg(cfg.colors.base04)
+                .bg(cfg.colors.base00)
+        });
+        let table = Table::new(rows, widths)
+            .header(header)
+            .flex(ratatui::layout::Flex::Center)
+            .highlight_symbol(HIGHLIGHT_SYMBOL)
+            .highlight_style(cfg.colors.base05)
+            .highlight_spacing(HighlightSpacing::Always);
+
+        StatefulWidget::render(table, area, buf, &mut table_state);
+    }
+
+    fn render_two_column_table(
+        left_label: &str,
+        right_label: &str,
+        rows_data: &[(String, String)],
+        area: Rect,
+        buf: &mut Buffer,
+    ) {
+        let cfg = config::get();
+        let mut table_state = TableState::default();
+        let widths = [Constraint::Percentage(50), Constraint::Percentage(50)];
+        let header = Row::new([Cell::from(left_label.bold()), Cell::from(right_label.bold())])
+            .top_margin(1)
+            .bottom_margin(1)
+            .fg(cfg.colors.base04)
+            .bg(cfg.colors.base02);
+
+        let rows = rows_data.iter().map(|(left, right)| {
+            Row::new([Cell::from(left.as_str()), Cell::from(right.as_str())])
+                .fg(cfg.colors.base04)
+                .bg(cfg.colors.base00)
+        });
+        let table = Table::new(rows, widths)
+            .header(header)
+            .widths(widths)
+            .flex(ratatui::layout::Flex::Center)
+            .highlight_symbol(HIGHLIGHT_SYMBOL)
+            .highlight_style(cfg.colors.base05)
+            .highlight_spacing(HighlightSpacing::Always);
+
+        StatefulWidget::render(table, area, buf, &mut table_state);
     }
 }
 
@@ -341,12 +314,7 @@ const HIGHLIGHT_SYMBOL: &str = " >> ";
 impl StatefulWidget for KeySpaceWidget {
     type State = KeySpace;
 
-    fn render(
-        self,
-        area: ratatui::prelude::Rect,
-        buf: &mut ratatui::prelude::Buffer,
-        state: &mut Self::State,
-    ) {
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
         let cfg = config::get();
         let [t_area, view_area] =
             Layout::horizontal([Constraint::Percentage(35), Constraint::Fill(1)])
@@ -383,19 +351,19 @@ impl StatefulWidget for KeySpaceWidget {
             .borders(Borders::all())
             .title("Filters");
 
-        let filters_area = filters_block.inner(filter_area);
+        let filters_inner = filters_block.inner(filter_area);
         filters_block.render(filter_area, buf);
 
         let [cursor_size_are, pattern_area] =
             Layout::vertical([Constraint::Length(1), Constraint::Min(1)])
                 .flex(ratatui::layout::Flex::Center)
-                .areas(filters_area);
+                .areas(filters_inner);
 
         let [cursor_area, size_area] = Layout::horizontal([Constraint::Min(1), Constraint::Min(1)])
             .flex(ratatui::layout::Flex::Center)
             .areas(cursor_size_are);
 
-        Paragraph::new(format!("Cursor: {}", state.cursor.unwrap_or_default()))
+        Paragraph::new(format!("Cursor: {cursor}", cursor = state.cursor.unwrap_or_default()))
             .bold()
             .alignment(Alignment::Left)
             .render(cursor_area, buf);
@@ -406,8 +374,8 @@ impl StatefulWidget for KeySpaceWidget {
             .render(size_area, buf);
 
         Paragraph::new(format!(
-            "Pattern: {}",
-            state.pattern.as_deref().unwrap_or_else(|| "*")
+            "Pattern: {pattern}",
+            pattern = state.pattern.as_deref().unwrap_or("*")
         ))
         .bold()
         .alignment(Alignment::Left)
@@ -456,10 +424,10 @@ impl StatefulWidget for KeySpaceWidget {
 
         StatefulWidget::render(table, table_area, buf, &mut state.table);
 
-        self.render_key_view(state, view_area, buf);
+        Self::render_key_view(state, view_area, buf);
 
         if state.is_popup() {
-            self.render_confirm_popup(state, area, buf)
+            Self::render_confirm_popup(state, area, buf);
         }
     }
 }


### PR DESCRIPTION
 - Remove unsound  Byte::from_u128_unsafe calls in the keyspace widget; use safe Byte::from_u128 with default fallback.
 - Swap std::sync::Mutex for parking_lot::Mutex across SharedState so panics in background tasks no longer poison the UI. Drop .unwrap() at every lock call site.
 - Pipeline TYPE / MEMORY USAGE / TTL into a single round-trip per page in storage.rs. Defer per-key value retrieval until row selection via a new RedisEvent::FetchValue, SharedState.selected_value, and the RequestSelectedValue / LoadSelectedValueIntoView actions. Bound value fetches to the first 100 items per collection.
 - Borrow keys during rendering instead of cloning the full Vec<KeyMeta> every frame; replace per-field clones in the detail tables with borrowed &str cells.
 - Cache config::get() once per render in keyspace, info, and the root AppWidget to avoid the per-cell OnceLock load.
 - Cap the Tui::new default frame_rate from 60 to 10 FPS.
 - Trigger an initial Action::LoadKeySpace after entering the TUI so existing keys appear without a manual